### PR TITLE
Added support for configuring the RPXNow HOST

### DIFF
--- a/lib/rpx_now.rb
+++ b/lib/rpx_now.rb
@@ -7,8 +7,11 @@ module RPXNow
 
   attr_accessor :api_key
   attr_accessor :api_version
+  attr_accessor :domain
+  
   self.api_version = 2
-
+  self.domain = 'rpxnow.com'
+  
   VERSION = File.read( File.join(File.dirname(__FILE__),'..','VERSION') ).strip
 
   # retrieve the users data

--- a/lib/rpx_now/api.rb
+++ b/lib/rpx_now/api.rb
@@ -8,7 +8,6 @@ module RPXNow
   # - parse response
   # - handle server errors
   class Api
-    HOST = 'rpxnow.com'
     SSL_CERT = File.join(File.dirname(__FILE__), '..', '..', 'certs', 'ssl_cert.pem')
 
     def self.call(method, data)
@@ -23,9 +22,9 @@ module RPXNow
 
     def self.host(subdomain=nil)
       if subdomain
-        "https://#{subdomain}.#{Api::HOST}"
+        "https://#{subdomain}.#{RPXNow.domain}"
       else
-        "https://#{Api::HOST}"
+        "https://#{RPXNow.domain}"
       end
     end
 
@@ -49,7 +48,7 @@ module RPXNow
     end
 
     def self.client
-      client = Net::HTTP.new(HOST, 443)
+      client = Net::HTTP.new(RPXNow.domain, 443)
       client.use_ssl = true
       client.ca_file = SSL_CERT
       client.verify_mode = OpenSSL::SSL::VERIFY_PEER

--- a/spec/rpx_now_spec.rb
+++ b/spec/rpx_now_spec.rb
@@ -5,23 +5,39 @@ describe RPXNow do
     body = {'stat' => 'ok'}.merge(replace)
     mock({:code => "200", :body => body.to_json})
   end
-
+  
+  describe :domain do  
+    it 'defaults to rpxnow.com' do
+      RPXNow.domain.should == 'rpxnow.com'
+    end
+  end
+  
+  describe :domain= do
+    before do
+      RPXNow.domain='domain.com'
+    end
+    
+    it "is stored" do
+      RPXNow.domain.should == 'domain.com'
+    end
+  end
+      
   describe :api_key= do
     before do
       RPXNow.api_key='XX'
     end
-
+  
     it "is stored" do
       RPXNow.api_key.should == 'XX'
     end
-
+  
     it "stores the api key, so i do not have to supply everytime" do
       RPXNow::Api.should_receive(:request).
         with(anything, hash_including(:apiKey => 'XX')).
         and_return fake_response
       RPXNow.mappings(1)
     end
-
+  
     it "is not overwritten when overwriting for a single request" do
       RPXNow::Api.should_receive(:request).
         with(anything, hash_including(:apiKey => 'YY')).
@@ -35,12 +51,12 @@ describe RPXNow do
     it "is 2 by default" do
       RPXNow.api_version.should == 2
     end
-
+  
     it "is stored" do
       RPXNow.api_version='XX'
       RPXNow.api_version.should == 'XX'
     end
-
+  
     it "used for every request" do
       RPXNow.api_version='XX'
       RPXNow::Api.should_receive(:request).
@@ -48,7 +64,7 @@ describe RPXNow do
         and_return fake_response
       RPXNow.mappings(1)
     end
-
+  
     it "is not overwritten when overwriting for a single request" do
       RPXNow.api_version='XX'
       RPXNow::Api.should_receive(:request).
@@ -57,7 +73,7 @@ describe RPXNow do
       RPXNow.mappings(1, :api_version => 'YY')
       RPXNow.api_version.should == 'XX'
     end
-
+  
     it "is not passed in data for request" do
       RPXNow.api_version='XX'
       RPXNow::Api.should_receive(:request).
@@ -66,7 +82,7 @@ describe RPXNow do
       RPXNow.mappings(1, :api_version => 'YY')
     end
   end
-
+  
   describe :embed_code do
     it "contains the subdomain" do
       RPXNow.embed_code('xxx','my_url').should =~ /xxx/
@@ -79,7 +95,7 @@ describe RPXNow do
     it "defaults to no language" do
       RPXNow.embed_code('xxx', 'my_url').should_not =~ /language_preference/
     end
-
+  
     it "has a changeable language" do
       RPXNow.embed_code('xxx', 'my_url', :language => 'es').should =~ /language_preference=es/
     end
@@ -104,28 +120,28 @@ describe RPXNow do
       RPXNow.embed_code('xxx','my_url').should =~ /id=\"rpx_now_embed\"/
     end
   end
-
+  
   describe :popup_code do
     it "defaults to obtrusive output" do
       RPXNow.popup_code('sign on', 'subdomain', 'http://fake.domain.com/').should =~ /script src=/
     end
-
+  
     it "does not change supplied options" do
       options = {:xxx => 1}
       RPXNow.popup_code('a','b','c', options)
       options.should == {:xxx => 1}
     end
-
+  
     it "adds html params to link" do
       options = {:html => {:id => "xxxx"}}
       RPXNow.popup_code('a','b','c', options).should =~ /id="xxxx"/
     end
-
+  
     it "adds rpxnow to given html class" do
       options = {:html => {:class => "c1 c2"}}
       RPXNow.popup_code('a','b','c', options).should =~ /class="rpxnow c1 c2"/
     end
-
+  
     describe 'obstrusive' do
       it "does not encode token_url for popup" do
         expected = %Q(RPXNOW.token_url = 'http://fake.domain.com/')
@@ -143,24 +159,24 @@ describe RPXNow do
         actual = RPXNow.popup_code('sign on', 'subdomain', 'http://fake.domain.com/', :unobtrusive => true)
         actual.should == expected
       end
-
+  
       it "can change api version" do
         RPXNow.popup_code('x', 'y', 'z', :unobtrusive => true, :api_version => 'XX').should include("openid/vXX/signin?")
       end
-
+  
       it "can change language" do
         RPXNow.popup_code('x', 'y', 'z', :unobtrusive => true, :language => 'XX').should include("language_preference=XX")
       end
-
+  
       it "can add flags" do
         RPXNow.popup_code('x', 'y', 'z', :unobtrusive => true, :flags => 'test').should include("flags=test")
       end
-
+  
       it "can add default_provider" do
         RPXNow.popup_code('x', 'y', 'z', :unobtrusive => true, :default_provider => 'test').should include("default_provider=test")
       end
     end
-
+  
     it "allows to specify the version of the widget" do
       RPXNow.popup_code('x','y','z', :api_version => 300).should =~ %r(/openid/v300/signin)
     end
@@ -168,38 +184,38 @@ describe RPXNow do
     it "defaults to widget version 2" do
       RPXNow.popup_code('x','y','z').should =~ %r(/openid/v2/signin)
     end
-
+  
     describe 'language' do
       it "defaults to no language" do
         RPXNow.popup_code('x','y','z').should_not =~ /RPXNOW.language_preference/
       end
-
+  
       it "has a changeable language" do
         RPXNow.popup_code('x','y','z', :language=>'de').should =~ /RPXNOW.language_preference = 'de'/
       end
     end
-
+  
     describe 'flags' do
       it "defaults to no language" do
         RPXNow.popup_code('x','y','z').should_not =~ /RPXNOW.flags/
       end
-
+  
       it "can have flags" do
         RPXNow.popup_code('x','y','z', :flags=>'test').should =~ /RPXNOW.flags = 'test'/
       end
     end
-
+  
     describe 'default_provider' do
       it "defaults to no provider" do
         RPXNow.popup_code('x','y','z').should_not =~ /RPXNOW.default_provider/
       end
-
+  
       it "can have default_provider" do
         RPXNow.popup_code('x','y','z', :default_provider=>'test').should =~ /RPXNOW.default_provider = 'test'/
       end
     end
   end
-
+  
   describe :user_data do
     before do
       @response_body = {
@@ -214,7 +230,7 @@ describe RPXNow do
       @response = fake_response(@response_body)
       @fake_user_data = {'profile'=>{}}
     end
-
+  
     it "raises ApiError when used with an invalid token" do
       lambda{
         RPXNow.user_data('xxxx')
@@ -235,13 +251,13 @@ describe RPXNow do
       RPXNow::Api.should_receive(:request).and_return @response
       RPXNow.user_data('').should == expected
     end
-
+  
     it "deprecated: adds raw profile data if i want it" do
       RPXNow::Api.should_receive(:request).and_return @response
       RPXNow.should_receive(:warn)
       RPXNow.user_data('',:additional => [:raw])[:raw]["verifiedEmail"].should == "grosser.michael@googlemail.com"
     end
-
+  
     it "adds raw data if i want it" do
       RPXNow::Api.should_receive(:request).and_return @response
       RPXNow.user_data('',:additional => [:raw_response])[:raw_response]['profile']["verifiedEmail"].should == "grosser.michael@googlemail.com"
@@ -253,14 +269,14 @@ describe RPXNow do
       RPXNow::Api.should_receive(:request).and_return response
       RPXNow.user_data('')[:id].should == '2'
     end
-
+  
     it "handles primaryKeys that are not numeric" do
       @response_body['profile']['primaryKey'] = "dbalatero"
       response = fake_response(@response_body)
       RPXNow::Api.should_receive(:request).and_return response
       RPXNow.user_data('')[:id].should == 'dbalatero'
     end
-
+  
     it "can fetch additional fields" do
       @response_body['profile']['xxxy'] = "test"
       response = fake_response(@response_body)
@@ -287,7 +303,7 @@ describe RPXNow do
         and_return @response
       RPXNow.user_data('', :extended=>true)
     end
-
+  
     it "returns extended data as an additional field" do
       @response_body['friends'] = {'x' => 1}
       @response = fake_response(@response_body)
@@ -295,19 +311,19 @@ describe RPXNow do
       RPXNow::Api.should_receive(:request).and_return @response
       RPXNow.user_data('', :extended=>true)[:extended].should == {'friends' => {'x' => 1}}
     end
-
+  
     it "does not pass raw_response to RPX" do
       RPXNow::Api.should_receive(:request).
         with(anything, hash_not_including(:raw_response => true)).
         and_return @response
       RPXNow.user_data('', :raw_response=>true)
     end
-
+  
     it "can return a raw_response" do
       RPXNow::Api.should_receive(:request).and_return @response
       RPXNow.user_data('', :raw_response=>true).should == @response_body.merge('stat' => 'ok')
     end
-
+  
     # these 2 tests are kind of duplicates of the api_version/key tests,
     # but i want to be extra-sure user_data works
     it "works with api version as option" do
@@ -317,7 +333,7 @@ describe RPXNow do
       RPXNow.user_data('id', :extended=>'abc', :api_version=>123)
       RPXNow.api_version.should == API_VERSION
     end
-
+  
     it "works with apiKey as option" do
       RPXNow::Api.should_receive(:request).
         with('/api/v2/auth_info', hash_including(:apiKey=>'THE KEY')).
@@ -326,7 +342,7 @@ describe RPXNow do
       RPXNow.api_key.should == API_KEY
     end
   end
-
+  
   describe :set_status do
     it "sets the status" do
       RPXNow::Api.should_receive(:request).
@@ -335,19 +351,19 @@ describe RPXNow do
       RPXNow.set_status('identifier', 'Chillen...')
     end
   end
-
+  
   describe :activity do
     it "does a api call with the right arguments" do
       RPXNow::Api.should_receive(:request).with("/api/v2/activity", :identifier=>"identifier", :activity=>'{"test":"something"}', :apiKey=>API_KEY).and_return fake_response 
       RPXNow.activity('identifier', :test => 'something')
     end
-
+  
     it "can pass identifier/apiKey" do
       RPXNow::Api.should_receive(:request).with("/api/v66666/activity", hash_including(:apiKey=>'MYKEY')).and_return fake_response
       RPXNow.activity('identifier', {:test => 'something'}, :apiKey => 'MYKEY', :api_version => '66666')
     end
   end
-
+  
   describe :parse_user_data do
     it "reads secondary names" do
       RPXNow.send(:parse_user_data,{'profile'=>{'preferredUsername'=>'1'}}, {})[:name].should == '1'
@@ -357,7 +373,7 @@ describe RPXNow do
       RPXNow.send(:parse_user_data,{'profile'=>{'email'=>'1@xxx.com'}}, {})[:name].should == '1'
     end
   end
-
+  
   describe :contacts do
     it "finds all contacts" do
       response = fake_response(JSON.parse(File.read('spec/fixtures/get_contacts_response.json')))
@@ -367,7 +383,7 @@ describe RPXNow do
       RPXNow.contacts('xx').size.should == 5
     end
   end
-
+  
   describe :mappings do
     it "shows all mappings" do
       RPXNow::Api.should_receive(:request).
@@ -376,7 +392,7 @@ describe RPXNow do
       RPXNow.mappings(1).should == ["http://test.myopenid.com/"]
     end
   end
-
+  
   describe :map do
     it "maps a identifier" do
       RPXNow::Api.should_receive(:request).
@@ -385,7 +401,7 @@ describe RPXNow do
       RPXNow.map('http://test.myopenid.com',1)
     end
   end
-
+  
   describe :unmap do
     it "unmaps a indentifier" do
       RPXNow::Api.should_receive(:request).
@@ -394,7 +410,7 @@ describe RPXNow do
       RPXNow.unmap('http://test.myopenid.com', 1)
     end
   end
-
+  
   it "has a VERSION" do
     RPXNow::VERSION.should =~ /^\d+\.\d+\.\d+$/
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,11 +4,13 @@ $LOAD_PATH << File.expand_path("../lib", File.dirname(__FILE__))
 require File.expand_path("../init", File.dirname(__FILE__))
 API_KEY = '4b339169026742245b754fa338b9b0aebbd0a733'
 API_VERSION = RPXNow.api_version
+DOMAIN = RPXNow.domain
 
 # ---- rspec
 RSpec.configure do |config|
   config.before :each do
     RPXNow.api_key = API_KEY
     RPXNow.api_version = API_VERSION
+    RPXNow.domain = DOMAIN
   end
 end


### PR DESCRIPTION
RPXNow previously used a hardcoded constant PRXNow::API::HOST to store the root domain for the RPX connection (rpxnow.com). However with Engage enterprise accounts, you can customize this (login.domain.com), so overwriting that HOST constant is not preferred. Added the ability to customize the RPXNow domain.
