### PR TITLE
fix javascript fallback reference

### DIFF
--- a/lib/rpx_now.rb
+++ b/lib/rpx_now.rb
@@ -133,7 +133,7 @@ module RPXNow
     when :legacy
       "#{Api.host(subdomain)}/openid/v#{extract_version(options)}/signin?#{embed_params(url, options)}"
     when :disable
-      "javacsript:void(0)"
+      "javascript:void(0)"
     else
       "#{Api.host(subdomain)}/openid/embed?#{embed_params(url, options)}"
     end

--- a/spec/rpx_now_spec.rb
+++ b/spec/rpx_now_spec.rb
@@ -300,7 +300,7 @@ describe RPXNow do
 
         describe 'fallback url' do
           it "encodes token_url" do
-            should include(%Q(<a class="rpxnow" href="javacsript:void(0)">sign on</a>))
+            should include(%Q(<a class="rpxnow" href="javascript:void(0)">sign on</a>))
           end
           context "when html href options provided" do
             let(:options) { {:html => {:href => "http://go.here.instead"}} }
@@ -320,7 +320,7 @@ describe RPXNow do
 
         describe 'fallback url' do
           it "encodes token_url" do
-            should == %Q(<a class="rpxnow" href="javacsript:void(0)">sign on</a>)
+            should == %Q(<a class="rpxnow" href="javascript:void(0)">sign on</a>)
           end
           context "when html href options provided" do
             let(:options) { {:html => {:href => "http://go.here.instead"}} }


### PR DESCRIPTION
This fixes a typo in the no-fallback option.

So previously I copy-pasted into test expectations and guess what? The tests passed when they shouldn't #fml!
