### PR TITLE
stopped it breaking full integration tests in capybara with PhantomJS

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+0.7.2
+-----
+* stopped it breaking full integration tests in capybara with PhantomJS, by defaulting RPXNOW to {} before setting its attributes
+
+(...)
+
 0.6.13
 ------
  * return an indifferent hash from user_data when possible

--- a/lib/rpx_now.rb
+++ b/lib/rpx_now.rb
@@ -115,6 +115,9 @@ module RPXNow
       <script src="#{Api.host}/openid/v#{extract_version(options)}/widget" type="text/javascript"></script>
       <script type="text/javascript">
         //<![CDATA[
+        if( typeof(RPXNOW) == 'undefined' ){
+          RPXNOW = {};
+        }
         RPXNOW.token_url = '#{url}';
         RPXNOW.realm = '#{subdomain}';
         RPXNOW.overlay = true;

--- a/lib/rpx_now/version.rb
+++ b/lib/rpx_now/version.rb
@@ -1,3 +1,3 @@
 module RPXNow
-  VERSION = "0.7.1"
+  VERSION = "0.7.2"
 end


### PR DESCRIPTION
...by defaulting RPXNOW to {} before setting its attributes
